### PR TITLE
missing JS var declaration (fixing #41)

### DIFF
--- a/src/Resources/public/js/setono-pickup-point.js
+++ b/src/Resources/public/js/setono-pickup-point.js
@@ -8,7 +8,7 @@ let pickupPoints = {
   pickupPointChoices: {},
   lastChosenPickupPointId: null,
   init: function (args) {
-    self = this;
+    var self = this;
     self.searchUrl = args.searchUrl;
 
     if (0 === self.pickupPointShippingMethods.length) {


### PR DESCRIPTION
Because of missing "var" in JS variable declaration, webpack encore return an error :
`self.postMessage is not a function`